### PR TITLE
search: added "inverse" search 

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/MediaActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/MediaActivity.kt
@@ -343,8 +343,10 @@ class MediaActivity : SimpleActivity(), MediaOperationsListener {
     private fun searchQueryChanged(text: String) {
         ensureBackgroundThread {
             try {
-                val filtered = mMedia.filter { it is Medium && it.name.contains(text, true) } as ArrayList
-                filtered.sortBy { it is Medium && !it.name.startsWith(text, true) }
+                val neg = text.startsWith("!")
+                val text2 = if (!neg) text else text.substring(1)
+                val filtered = mMedia.filter { it is Medium && (if (neg) !it.name.contains(text2, true) else it.name.contains(text2, true)) } as ArrayList
+                filtered.sortBy { it is Medium && !it.name.startsWith(text2, true) }
                 val grouped = MediaFetcher(applicationContext).groupMedia(filtered as ArrayList<Medium>, mPath)
                 runOnUiThread {
                     if (grouped.isEmpty()) {

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/SearchActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/SearchActivity.kt
@@ -107,8 +107,10 @@ class SearchActivity : SimpleActivity(), MediaOperationsListener {
     private fun textChanged(text: String) {
         ensureBackgroundThread {
             try {
-                val filtered = mAllMedia.filter { it is Medium && it.name.contains(text, true) } as ArrayList
-                filtered.sortBy { it is Medium && !it.name.startsWith(text, true) }
+                val neg = text.startsWith("!")
+                val text2 = if (!neg) text else text.substring(1)
+                val filtered = mAllMedia.filter { it is Medium && (if (neg) !it.name.contains(text2, true) else it.name.contains(text2, true)) } as ArrayList
+                filtered.sortBy { it is Medium && !it.name.startsWith(text2, true) }
                 val grouped = MediaFetcher(applicationContext).groupMedia(filtered as ArrayList<Medium>, "")
                 runOnUiThread {
                     if (grouped.isEmpty()) {


### PR DESCRIPTION
If you prefix "!" a search term to show only items not containing that term.
I find this feature useful when I rename items.
